### PR TITLE
Fixed construct

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -122,7 +122,7 @@ var async = {
         indexes = keys(obj);
         remain = indexes.length;
         index = 0;
-        
+
         if (!remain) {
             return callback();
         }
@@ -531,23 +531,16 @@ var createObject = (function() {
  * @param {Function} constructor
  * @param {Array} args
  */
-var construct = (function(root) {
-	if (isObject(root.Reflect) && isFunction(root.Reflect.construct)) {
-		return root.Reflect.construct;
-	} else {
-		return function(constructor, args) {
-            var that = createObject(constructor.prototype);
-            var service = constructor.apply(that, args);
-
-            // if constructor returned object or function - return this value
-            if (service && (typeof service == 'object' || typeof service == 'function')) {
-            	return service;
-            }
-
-            return that;
-		};
-	}
-})(this);
+var construct = (function() {
+    if (isObject(Reflect)) {
+        return Reflect.construct;
+    } else {
+        return function(constructor, args) {
+            args.unshift(null);
+            return new (Function.bind.apply(constructor, args));
+        };
+    }
+})();
 
 
 module.exports = {


### PR DESCRIPTION
Hey! `this` on top-level within node.js refers to `exports` object (not to the browser window object), so that `root.Reflect` is always `undefined`, also `apply` didn't work with constructor without `new` and died with error `TypeError: Class constructor  cannot be invoked without 'new'` (solution can find [here](http://stackoverflow.com/questions/1606797/use-of-apply-with-new-operator-is-this-possible)), also one could use [spread operator](http://stackoverflow.com/a/32548260/2868530) for that, but it will work only for es6.

Also you mixed the tabs and spaces in your pull request.